### PR TITLE
Fix brainstorm to use default CLI

### DIFF
--- a/src-tauri/src/commands/project_commands.rs
+++ b/src-tauri/src/commands/project_commands.rs
@@ -248,9 +248,15 @@ pub async fn ai_brainstorm_chat(
 ) -> Result<AiBrainstormResponse, String> {
     let uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let state = storage::load_project_state(&uuid).map_err(|e| e.to_string())?;
+    let config = storage::load_config().map_err(|e| e.to_string())?;
 
     let working_dir = PathBuf::from(&state.path);
-    run_ai_brainstorm(&working_dir, &conversation)
+    run_ai_brainstorm(
+        &working_dir,
+        &conversation,
+        config.default_cli,
+        state.skip_git_repo_check,
+    )
         .await
         .map_err(|e| security::sanitize_log(&e))
 }


### PR DESCRIPTION
## Summary
- use configured default CLI for brainstorm runs
- support Codex/OpenCode adapters for brainstorm output parsing
- add regression test for default CLI selection

## Testing
- cargo test brainstorm_uses_configured_cli -- --nocapture