### PR TITLE
fix: auto-detect default CLI for first-time users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-desktop",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ralph-desktop"
-version = "0.1.8"
+version = "0.1.9"
 description = "Ralph Desktop - Visual Ralph Loop Controller"
 authors = ["刘小排"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ralph Desktop",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.ralph-desktop.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Add `detect_default_cli()` to check which CLI is installed
- Prioritize: Claude > Codex > OpenCode
- Fixes 'Failed to run claude: program not found' for users who only have Codex/OpenCode installed

## Changes
- `src-tauri/src/storage/mod.rs`: Add auto-detection logic on first config creation
- Bump version to 0.1.9

## Testing
First-time users with only Codex installed will now have Codex set as default CLI instead of Claude.