### PR TITLE
fix: improve JSON parsing to handle truncated AI responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ralph-desktop"
-version = "0.1.9"
+version = "0.1.10"
 description = "Ralph Desktop - Visual Ralph Loop Controller"
 authors = ["刘小排"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ralph Desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.ralph-desktop.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
修复 'EOF while parsing a string' 错误，当 AI 返回不完整的 JSON 时不再崩溃。

## Changes
- 使用括号配对算法替代简单的 `rfind('}')`
- 新增 `extract_balanced_json()` 精确提取 JSON
- 新增 `validate_json_structure()` 验证 JSON 完整性
- 新增 `truncate_for_error()` 生成简洁的错误信息
- 提供用户友好的错误提示

## Root Cause
原代码用 `rfind('}')` 简单查找最后一个 `}`，无法正确处理：
- 嵌套 JSON
- 截断的 JSON
- 字符串内包含 `}` 的情况

## Testing
当 AI 返回截断的 JSON 时，现在会显示友好的错误信息而不是崩溃。

Bump version to 0.1.10