### PR TITLE
fix(windows): hide console window when spawning CLI/git

### DIFF
--- a/src-tauri/src/adapters/claude.rs
+++ b/src-tauri/src/adapters/claude.rs
@@ -1,6 +1,6 @@
 use super::{
-    apply_extended_path, apply_shell_env, command_for_cli, resolve_cli_path, CliAdapter,
-    CommandOptions, LineType, ParsedLine,
+    apply_extended_path, apply_shell_env, command_for_cli, hide_console_window, resolve_cli_path,
+    CliAdapter, CommandOptions, LineType, ParsedLine,
 };
 use crate::storage::models::CliType;
 use async_trait::async_trait;
@@ -43,6 +43,7 @@ impl CliAdapter for ClaudeCodeAdapter {
         let mut cmd = Command::new(exe);
         apply_extended_path(&mut cmd);
         apply_shell_env(&mut cmd);
+        hide_console_window(&mut cmd);
         let output = cmd.arg("--version").output().await.ok()?;
 
         if output.status.success() {

--- a/src-tauri/src/adapters/codex.rs
+++ b/src-tauri/src/adapters/codex.rs
@@ -1,6 +1,6 @@
 use super::{
-    apply_extended_path, apply_shell_env, command_for_cli, resolve_cli_path, CliAdapter,
-    CommandOptions, LineType, ParsedLine,
+    apply_extended_path, apply_shell_env, command_for_cli, hide_console_window, resolve_cli_path,
+    CliAdapter, CommandOptions, LineType, ParsedLine,
 };
 use crate::storage::models::CliType;
 use async_trait::async_trait;
@@ -88,6 +88,7 @@ impl CliAdapter for CodexAdapter {
         let mut cmd = Command::new(exe);
         apply_extended_path(&mut cmd);
         apply_shell_env(&mut cmd);
+        hide_console_window(&mut cmd);
         let output = cmd.arg("--version").output().await.ok()?;
 
         if output.status.success() {

--- a/src-tauri/src/adapters/opencode.rs
+++ b/src-tauri/src/adapters/opencode.rs
@@ -1,8 +1,6 @@
 use super::{
-    apply_extended_path, apply_shell_env, command_for_cli, resolve_cli_path, shell_env_has,
-    shell_env_value,
-    CliAdapter,
-    CommandOptions, LineType, ParsedLine,
+    apply_extended_path, apply_shell_env, command_for_cli, hide_console_window, resolve_cli_path,
+    shell_env_has, shell_env_value, CliAdapter, CommandOptions, LineType, ParsedLine,
 };
 use crate::storage::models::CliType;
 use async_trait::async_trait;
@@ -244,6 +242,7 @@ impl CliAdapter for OpenCodeAdapter {
         let mut cmd = Command::new(exe);
         apply_extended_path(&mut cmd);
         apply_shell_env(&mut cmd);
+        hide_console_window(&mut cmd);
         let output = cmd.arg("--version").output().await.ok()?;
 
         if output.status.success() {

--- a/src-tauri/src/auto_update.rs
+++ b/src-tauri/src/auto_update.rs
@@ -8,6 +8,12 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateStatus {
@@ -385,7 +391,9 @@ pub async fn apply_pending_update() -> storage::Result<()> {
 
         #[cfg(target_os = "windows")]
         {
-            let _ = std::process::Command::new(&file_path).spawn();
+            let mut cmd = std::process::Command::new(&file_path);
+            cmd.creation_flags(CREATE_NO_WINDOW);
+            let _ = cmd.spawn();
         }
 
         #[cfg(target_os = "linux")]

--- a/src-tauri/src/commands/loop_commands.rs
+++ b/src-tauri/src/commands/loop_commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::adapters::hide_console_window;
 use crate::engine::{LoopEngine, LoopEvent, CODEX_GIT_REPO_CHECK_REQUIRED};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -161,9 +162,10 @@ fn ensure_autodecide_prompt(task: &mut TaskConfig) -> bool {
 }
 
 async fn init_git_repo(project_path: &PathBuf) -> Result<(), String> {
-    let output = Command::new("git")
-        .arg("init")
-        .current_dir(project_path)
+    let mut cmd = Command::new("git");
+    cmd.arg("init").current_dir(project_path);
+    hide_console_window(&mut cmd);
+    let output = cmd
         .output()
         .await
         .map_err(|e| format!("Failed to run git: {}", e))?;
@@ -177,12 +179,13 @@ async fn init_git_repo(project_path: &PathBuf) -> Result<(), String> {
 }
 
 async fn is_git_repo(project_path: &PathBuf) -> Result<bool, String> {
-    let output = Command::new("git")
-        .arg("-C")
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
         .arg(project_path)
         .arg("rev-parse")
-        .arg("--is-inside-work-tree")
-        .output()
+        .arg("--is-inside-work-tree");
+    hide_console_window(&mut cmd);
+    let output = cmd.output()
         .await
         .map_err(|e| format!("Failed to run git: {}", e))?;
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -10,6 +10,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 #[cfg(target_os = "windows")]
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+use crate::adapters::hide_console_window;
 use tokio::sync::Notify;
 
 pub mod ai_brainstorm;
@@ -210,10 +211,10 @@ Diff:
     }
 
     async fn run_git(&self, args: &[&str]) -> Result<String, String> {
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(&self.project_path)
-            .args(args)
+        let mut cmd = Command::new("git");
+        cmd.arg("-C").arg(&self.project_path).args(args);
+        hide_console_window(&mut cmd);
+        let output = cmd
             .output()
             .await
             .map_err(|e| format!("Failed to run git: {e}"))?;
@@ -227,11 +228,13 @@ Diff:
     }
 
     async fn is_git_repo(&self) -> Result<bool, String> {
-        let output = Command::new("git")
-            .arg("-C")
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
             .arg(&self.project_path)
             .arg("rev-parse")
-            .arg("--is-inside-work-tree")
+            .arg("--is-inside-work-tree");
+        hide_console_window(&mut cmd);
+        let output = cmd
             .output()
             .await
             .map_err(|e| format!("Failed to run git: {e}"))?;


### PR DESCRIPTION
## 背景
Windows 用户反馈：每次提问会弹出黑色 cmd 窗口，且等待时间很长，体验尴尬（Issue #6 也提到类似现象）。

## 变更
- 在 Windows 下对  统一应用 （通过  helper）
- 覆盖 CLI 相关进程（claude/codex/opencode）及 git 调用（repo check/init 等）
- auto_update 在 Windows 下启动安装器也加 

## 影响
- Windows 下不再弹出黑框
- 非 Windows 平台无行为变化（cfg + no-op）

## 测试
- Codex 复审：APPROVED（无 required changes）

Closes: （新 issue 见下）